### PR TITLE
Added tracking ID

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ description: >
 baseurl: ""
 url: "https://gigsterous.github.io"
 github_username:  gigsterous
+google_analytics: UA-83738456-1
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
After creating an account on GA, this commit includes the Tracking ID
assigned by Google for the blog.

Related to #6 
